### PR TITLE
fix: Ignore number inputs with control key

### DIFF
--- a/src/components/ExerciseMultipleChoice.tsx
+++ b/src/components/ExerciseMultipleChoice.tsx
@@ -90,7 +90,7 @@ export function ExerciseMultipleChoice({
         return
       }
       const num = parseInt(key)
-      if (!Number.isNaN(num) && num >= 1 && num <= answers.length && (e as KeyboardEvent).ctrlKey) {
+      if (!Number.isNaN(num) && num >= 1 && num <= answers.length && !(e as KeyboardEvent).ctrlKey) {
         e.preventDefault()
         const id = answers[num - 1].key
         setCheckedEntry(id, !checked.includes(id))

--- a/src/components/ExerciseMultipleChoice.tsx
+++ b/src/components/ExerciseMultipleChoice.tsx
@@ -90,7 +90,7 @@ export function ExerciseMultipleChoice({
         return
       }
       const num = parseInt(key)
-      if (!Number.isNaN(num) && num >= 1 && num <= answers.length) {
+      if (!Number.isNaN(num) && num >= 1 && num <= answers.length && (e as KeyboardEvent).ctrlKey) {
         e.preventDefault()
         const id = answers[num - 1].key
         setCheckedEntry(id, !checked.includes(id))

--- a/src/components/ExerciseMultipleChoice.tsx
+++ b/src/components/ExerciseMultipleChoice.tsx
@@ -80,9 +80,9 @@ export function ExerciseMultipleChoice({
 
   useGlobalDOMEvents({
     keydown(e: Event) {
-      const kbEvent = e as KeyboardEvent;
+      const kbEvent = e as KeyboardEvent
       if (kbEvent.ctrlKey || kbEvent.metaKey || kbEvent.altKey) {
-        return;
+        return
       }
 
       if (kbEvent.key === "Enter") {

--- a/src/components/ExerciseMultipleChoice.tsx
+++ b/src/components/ExerciseMultipleChoice.tsx
@@ -80,8 +80,12 @@ export function ExerciseMultipleChoice({
 
   useGlobalDOMEvents({
     keydown(e: Event) {
-      const key = (e as KeyboardEvent).key
-      if (key === "Enter") {
+      const kbEvent = e as KeyboardEvent;
+      if (kbEvent.ctrlKey || kbEvent.metaKey || kbEvent.altKey) {
+        return;
+      }
+
+      if (kbEvent.key === "Enter") {
         e.preventDefault()
         handleClick()
         return
@@ -89,8 +93,8 @@ export function ExerciseMultipleChoice({
       if (mode === "correct" || mode === "incorrect") {
         return
       }
-      const num = parseInt(key)
-      if (!Number.isNaN(num) && num >= 1 && num <= answers.length && !(e as KeyboardEvent).ctrlKey) {
+      const num = parseInt(kbEvent.key)
+      if (!Number.isNaN(num) && num >= 1 && num <= answers.length) {
         e.preventDefault()
         const id = answers[num - 1].key
         setCheckedEntry(id, !checked.includes(id))


### PR DESCRIPTION
This fixes an issue with switching tabs using the
keyboard shortcuts (Ctrl + 1 for tab 1, etc.).

Previously, all number inputs were used to select & deselect inputs, now we only perform this action if the control key is not pressed.