### PR TITLE
fix: sort receives correct correctAnswerIndex

### DIFF
--- a/shared/src/question-generators/asymptotics/sort.ts
+++ b/shared/src/question-generators/asymptotics/sort.ts
@@ -93,7 +93,6 @@ export const SortTerms: QuestionGenerator = {
       text: `$${t.toLatex(variable, true)}$`,
       correctIndex: t.correctIndex,
     }))
-
     const question: MultipleChoiceQuestion = {
       type: "MultipleChoiceQuestion",
       sorting: true,
@@ -107,7 +106,9 @@ export const SortTerms: QuestionGenerator = {
       text: t("text"),
       answers: answers.map((a) => a.text),
       feedback: minimalMultipleChoiceFeedback({
-        correctAnswerIndex: answers.map((a) => a.correctIndex),
+        correctAnswerIndex: answers
+          .sort((a, b) => a.correctIndex - b.correctIndex)
+          .map((a) => a.index),
         sorting: true,
       }),
     }


### PR DESCRIPTION
The passed correctAnswerIndex did not represent the correct solution. 
Example: [4,2,0,1,3] represented that the element in index 0 should move to index 4, the element in index 1 to index 2, etc. 
This example would result in [2,3,1,4,0], which is the correct solution but does not equal [4,2,0,1,3], which results in the failure message.
To pass the correct solution, the answers array gets sorted by the correctIndex and then the index value of the objects get passed.