### PR TITLE
Fix: Change variant log and feedback for nifty

### DIFF
--- a/shared/src/question-generators/asymptotics/between.ts
+++ b/shared/src/question-generators/asymptotics/between.ts
@@ -85,7 +85,7 @@ export const Between: QuestionGenerator = {
     let text: string
     const functionDeclaration = `${functionName}\\colon\\mathbb N\\to\\mathbb R`
     if (variant === "nifty") {
-      const condTheta = `${functionName}(${variable}) \\in ${`${"\\Theta"}(${functionName}(${variable})^c) \\quad \\forall c \\in \\mathbb{R}`}`
+      const condTheta = `${functionName}(${variable}) \\in ${`${"\\Theta"}(${functionName}(${variable})^${random.int(2, 9)})`}`
       text = t("Theta.text", [functionDeclaration, condTheta])
     } else {
       const aTeX = `${aLandau}(${a.toLatex(variable)})`

--- a/shared/src/question-generators/asymptotics/between.ts
+++ b/shared/src/question-generators/asymptotics/between.ts
@@ -180,7 +180,9 @@ ${t("feedback.expected")}: $${variable}$.`,
 
       if (variant === "nifty") {
         // create a solution for Theta(1)
-        const solution = new ProductTerm()
+        const solution = new ProductTerm({
+          coefficient: 1,
+        })
         return {
           correct: solution.Theta(sumProductTerm.dominantTerm()),
           feedbackText:
@@ -261,20 +263,12 @@ export function generateBaseFunction(variant: string, random: Random): ProductTe
           maxDenominator: 3,
           random,
         }),
-        logexponent: random.choice([
-          sampleFraction({
-            fractionProbability: 0,
-            minInt: -17,
-            maxInt: -1,
-            random,
-          }),
-          sampleFraction({
-            fractionProbability: 0,
-            minInt: 1,
-            maxInt: 17,
-            random,
-          }),
-        ]),
+        logexponent: sampleFraction({
+          fractionProbability: 0,
+          minInt: 1,
+          maxInt: 17,
+          random,
+        }).mul(random.choice([-1, 1])),
       })
       const b = createProductTerm({
         coefficient: sampleFraction({
@@ -287,20 +281,12 @@ export function generateBaseFunction(variant: string, random: Random): ProductTe
           maxDenominator: 3,
           random,
         }),
-        logexponent: random.choice([
-          sampleFraction({
-            fractionProbability: 0,
-            minInt: -17,
-            maxInt: -1,
-            random,
-          }),
-          sampleFraction({
-            fractionProbability: 0,
-            minInt: 1,
-            maxInt: 17,
-            random,
-          }),
-        ]),
+        logexponent: sampleFraction({
+          fractionProbability: 0,
+          minInt: 1,
+          maxInt: 17,
+          random,
+        }).mul(random.choice([-1, 1])),
       })
       a.logarithmExponents.get(1).n = 0
       b.logarithmExponents.get(0).n = a.logarithmExponents.get(0).n

--- a/shared/src/question-generators/asymptotics/between.ts
+++ b/shared/src/question-generators/asymptotics/between.ts
@@ -85,7 +85,7 @@ export const Between: QuestionGenerator = {
     let text: string
     const functionDeclaration = `${functionName}\\colon\\mathbb N\\to\\mathbb R`
     if (variant === "nifty") {
-      const condTheta = `${functionName}(${variable}) \\in ${`${"\\Theta"}(${functionName}(${variable})^2)`}`
+      const condTheta = `${functionName}(${variable}) \\in ${`${"\\Theta"}(${functionName}(${variable})^c) \\quad \\forall c \\in \\mathbb{R}`}`
       text = t("Theta.text", [functionDeclaration, condTheta])
     } else {
       const aTeX = `${aLandau}(${a.toLatex(variable)})`
@@ -179,11 +179,10 @@ ${t("feedback.expected")}: $${variable}$.`,
       }
 
       if (variant === "nifty") {
+        // create a solution for Theta(1)
+        const solution = new ProductTerm()
         return {
-          correct:
-            sumProductTerm.getTerms()[0].exponentialBase.n === 1 &&
-            sumProductTerm.getTerms()[0].exponentialBase.d === 1 &&
-            sumProductTerm.getTerms()[0].logarithmExponents.size === 0,
+          correct: solution.Theta(sumProductTerm.dominantTerm()),
           feedbackText:
             "$" +
             mathNode.toTex({
@@ -262,12 +261,20 @@ export function generateBaseFunction(variant: string, random: Random): ProductTe
           maxDenominator: 3,
           random,
         }),
-        logexponent: sampleFraction({
-          fractionProbability: 0,
-          minInt: -17,
-          maxInt: 17,
-          random,
-        }),
+        logexponent: random.choice([
+          sampleFraction({
+            fractionProbability: 0,
+            minInt: -17,
+            maxInt: -1,
+            random,
+          }),
+          sampleFraction({
+            fractionProbability: 0,
+            minInt: 1,
+            maxInt: 17,
+            random,
+          }),
+        ]),
       })
       const b = createProductTerm({
         coefficient: sampleFraction({
@@ -280,12 +287,20 @@ export function generateBaseFunction(variant: string, random: Random): ProductTe
           maxDenominator: 3,
           random,
         }),
-        logexponent: sampleFraction({
-          fractionProbability: 0,
-          minInt: -17,
-          maxInt: 17,
-          random,
-        }),
+        logexponent: random.choice([
+          sampleFraction({
+            fractionProbability: 0,
+            minInt: -17,
+            maxInt: -1,
+            random,
+          }),
+          sampleFraction({
+            fractionProbability: 0,
+            minInt: 1,
+            maxInt: 17,
+            random,
+          }),
+        ]),
       })
       a.logarithmExponents.get(1).n = 0
       b.logarithmExponents.get(0).n = a.logarithmExponents.get(0).n


### PR DESCRIPTION
[Testing location](https://tcs.uni-frankfurt.de/algo-learn-testing/pull_request_24/en)

For the variant log, I modified the random numbers to range from `17,...,-1,1,...,17` instead of `-17,...,17`. Including `0` can result in two terms having the same asymptotic growth.

For `nifty feedback`, I removed the array indexing and replaced it with a comparison of the dominant terms. For integers from `-\infty to 0`, the input evaluates to false. For all other integers, it evaluates to true.

Additionally, a small change has been made to `variant nifty`. Instead of only considering `f(n)^2 `, I replaced 2 with `random.int(2, 9)`