### PR TITLE
Sorting - Added ArrowUp/Down Buttons

### DIFF
--- a/front-end/src/components/SortableList.tsx
+++ b/front-end/src/components/SortableList.tsx
@@ -1,7 +1,14 @@
 import { GripHorizontal } from "lucide-react"
 import { memo, ReactNode } from "react"
 import { FaArrowDown, FaArrowUp } from "react-icons/fa"
-import { DndContext, KeyboardSensor, PointerSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core"
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
 import { cn } from "@/lib/utils"
 import { SortableItem } from "./SortableItem"
@@ -44,7 +51,7 @@ export function SortableList({ items, onChange, className = "", disabled = false
         delay: 250,
         tolerance: 5,
       },
-    })
+    }),
   )
   if (new Set(items.map(({ position }) => position)).size !== items.length) {
     throw new Error("Duplicate positions in SortableList!")

--- a/front-end/src/components/SortableList.tsx
+++ b/front-end/src/components/SortableList.tsx
@@ -1,7 +1,7 @@
 import { GripHorizontal } from "lucide-react"
 import { memo, ReactNode } from "react"
 import { FaArrowDown, FaArrowUp } from "react-icons/fa"
-import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core"
+import { DndContext, KeyboardSensor, PointerSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core"
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
 import { cn } from "@/lib/utils"
 import { SortableItem } from "./SortableItem"
@@ -38,6 +38,13 @@ export function SortableList({ items, onChange, className = "", disabled = false
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
+    useSensor(TouchSensor, {
+      // Press delay of 250ms, with tolerance of 5px of movement
+      activationConstraint: {
+        delay: 250,
+        tolerance: 5,
+      },
+    })
   )
   if (new Set(items.map(({ position }) => position)).size !== items.length) {
     throw new Error("Duplicate positions in SortableList!")
@@ -65,7 +72,7 @@ export function SortableList({ items, onChange, className = "", disabled = false
           role="application"
         >
           {itemsWithIds.map((item, index) => (
-            <li key={item.id} className="flex items-center">
+            <div key={item.id} className="flex items-center">
               <div className={`inline-block items-center justify-center sm:hidden`}>
                 <MemoizedButton
                   variant="ghost"
@@ -91,7 +98,7 @@ export function SortableList({ items, onChange, className = "", disabled = false
                 </Button>
                 <div></div>
               </SortableList.Item>
-            </li>
+            </div>
           ))}
         </ul>
       </SortableContext>

--- a/front-end/src/components/SortableList.tsx
+++ b/front-end/src/components/SortableList.tsx
@@ -1,5 +1,6 @@
 import { GripHorizontal } from "lucide-react"
-import { ReactNode } from "react"
+import { memo, ReactNode } from "react"
+import { FaArrowDown, FaArrowUp } from "react-icons/fa"
 import { DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core"
 import { arrayMove, SortableContext, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
 import { cn } from "@/lib/utils"
@@ -30,6 +31,8 @@ export interface Props {
  * @param props.children Children of the list.
  */
 export function SortableList({ items, onChange, className = "", disabled = false, ...props }: Props) {
+  const MemoizedButton = memo(Button)
+
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -61,14 +64,34 @@ export function SortableList({ items, onChange, className = "", disabled = false
           className={cn("mx-auto flex max-w-max list-none flex-col gap-2", className)}
           role="application"
         >
-          {itemsWithIds.map((item) => (
-            <SortableList.Item key={item.id} id={item.id} disabled={disabled}>
-              <GripHorizontal />
-              <Button variant="outline" asChild>
-                <div>{item.element}</div>
-              </Button>
-              <div></div>
-            </SortableList.Item>
+          {itemsWithIds.map((item, index) => (
+            <li key={item.id} className="flex items-center">
+              <div className={`inline-block items-center justify-center sm:hidden`}>
+                <MemoizedButton
+                  variant="ghost"
+                  size="sm"
+                  className={`${index === 0 ? "invisible" : "visible"} mr-0.5`}
+                  onClick={() => onChange(arrayMove(items, index, index - 1))}
+                >
+                  <FaArrowUp />
+                </MemoizedButton>
+                <MemoizedButton
+                  variant="ghost"
+                  size="sm"
+                  className={`${index === itemsWithIds.length - 1 ? "invisible" : "visible"} mr-0.5`}
+                  onClick={() => onChange(arrayMove(items, index, index + 1))}
+                >
+                  <FaArrowDown />
+                </MemoizedButton>
+              </div>
+              <SortableList.Item id={item.id} disabled={disabled}>
+                <GripHorizontal className="hidden sm:flex" />
+                <Button variant="outline" asChild className="flex-grow text-center">
+                  <div>{item.element}</div>
+                </Button>
+                <div></div>
+              </SortableList.Item>
+            </li>
           ))}
         </ul>
       </SortableContext>


### PR DESCRIPTION
When the user is on a smaller device (likely a mobile device), `ArrowUp` and `ArrowDown` button are displayed instead of the `GripHorizontal` icon. These buttons allow the user to change the ordering. 

Drag-and-drop functionality over the formula button remains available for reordering.